### PR TITLE
Runtime error locations

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -7,6 +7,8 @@ import * as babylon from 'babylon';
 import * as visitor from './visitor';
 import { CompileOK, CompileError } from './types';
 
+export { CompileOK, CompileError } from './types';
+
 /**
  * 
  * @param code the program to compile

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -89,7 +89,15 @@ export class State implements CompileError {
 
 function dynCheck(name: string, ...args: t.Expression[]): t.CallExpression {
   const f = t.memberExpression(t.identifier('rts'), t.identifier(name), false);
-  return t.callExpression(f, args);
+  const c = t.callExpression(f, args);
+  // Use the location of the first argument to the dynamic check as the location
+  // of CallExpression, which is what Stopify uses to report stack traces.
+  // This should be good enough for most cases. If we need finer control, we
+  // could add an optional SourceLocation argument to the dynCheck function.
+  if (args.length > 0) {
+    c.loc = args[0].loc;
+  }
+  return c;
 }
 
 interface S {


### PR DESCRIPTION
Before:

<img width="485" alt="before" src="https://user-images.githubusercontent.com/20065/43992820-4da4460c-9d52-11e8-95df-7dca5f086c40.png">

After:

<img width="509" alt="after" src="https://user-images.githubusercontent.com/20065/43992824-53cbc6e0-9d52-11e8-9ead-872b815881a6.png">

Thoughts, @joydeep-b ?