### PR TITLE
Blank image

### DIFF
--- a/ts/lib220.ts
+++ b/ts/lib220.ts
@@ -21,7 +21,7 @@ class FudgedImageData implements ImageData {
 }
 
 function createImageData(w: number, h: number): ImageData {
-  if (ImageData !== undefined) {
+  if (typeof ImageData !== 'undefined') {
     return new ImageData(w, h);
   }
   else {

--- a/ts/lib220.ts
+++ b/ts/lib220.ts
@@ -107,7 +107,8 @@ function EncapsulatedImage(imageData: any) {
 
 export function loadImageFromURL(url: any) {
   if (typeof document === 'undefined') {
-    return; // for node
+    return EncapsulatedImage(createImageData(50, 50));
+    // TODO (Sam): student can get a pixel that is out of bound.
   }
   const runnerResult = getRunner();
   if (runnerResult.kind === 'error') {
@@ -144,7 +145,7 @@ export function loadImageFromURL(url: any) {
 }
 
 export function createImage(width: number, height: number, fill?: [number, number, number]) {
-  let img = EncapsulatedImage(new ImageData(width, height));
+  let img = EncapsulatedImage(createImageData(width, height));
   if (typeof fill !== 'undefined') {
     assertValidPixel(fill);
     let i, j;


### PR DESCRIPTION
- `loadImageFromURL` when run on node returns a blank (filled with black) image
- made `createImage` use `createImageData`
- made `createImageData` check for `ImageData` by using `typeof` (else node throws an error)