### PR TITLE
For statement static check

### DIFF
--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -546,6 +546,45 @@ test('if else must be BlockStatement', () => {
   `)).toBe(2);
 });
 
+test('for statement must have three parts present', () => {
+  expect(staticError(`
+    for (;;) {
+      break;
+    }
+  `)).toEqual(expect.arrayContaining([
+    `for statement variable initialization must be present`,
+    `for statement termination test must be present`,
+    `for statement update expression must be present`
+  ]));
+  expect(staticError(`
+    for (let i = 0;;) {
+      break;
+    }
+  `)).toEqual(expect.arrayContaining([
+    `for statement termination test must be present`,
+    `for statement update expression must be present`
+  ]));
+  expect(staticError(`
+    for (let i = 0; i < 10;) {
+      break;
+    }
+  `)).toEqual(expect.arrayContaining([
+    `for statement update expression must be present`
+  ]));
+  expect(staticError(`
+    for (something(); i < 10; ++i) {
+      break;
+    }
+  `)).toEqual(expect.arrayContaining([
+    `for statement variable initialization must be an assignment or a variable declaration`
+  ]));
+  expect(run(`
+    let i = 0;
+    for (i = 0; i < 3; ++i) {}
+    i;
+  `)).toBe(3);
+});
+
 describe('ElementaryJS Testing', () => {
 
   beforeEach(() => {

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -392,6 +392,20 @@ export const visitor = {
     }
   },
   ForStatement(path: NodePath<t.ForStatement>, st: S) {
+    if (path.node.init === null) {
+      st.elem.error(path, `for statement variable initialization must be present`);
+    }
+    if (path.node.init !== null && 
+      !t.isAssignmentExpression(path.node.init) && 
+      !t.isVariableDeclaration(path.node.init)) {
+      st.elem.error(path, `for statement variable initialization must be an assignment or a variable declaration`);
+    }
+    if (path.node.test === null) {
+      st.elem.error(path, `for statement termination test must be present`);
+    }
+    if (path.node.update === null) {
+      st.elem.error(path, `for statement update expression must be present`);
+    }
     if (!t.isBlockStatement(path.node.body)) {
       st.elem.error(path, `Loop body must be enclosed in braces.`);
     }


### PR DESCRIPTION
- `for` statement static check
- Disallow for statements with empty `init`, `test` and `update` statements.
- e.g. `for (;;) {}`
- It allows statements of the form, `for (let i = 0; i < 10; ++i) {}` and `let i = 0; for (i = 0; i < 10; ++i) {}`