### PR TITLE
Dynamically check operators || and && for booleans

### DIFF
--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -665,6 +665,16 @@ test('for statement must have three parts present', () => {
   `)).toBe(3);
 });
 
+test('Only booleans for logical operators', () => {
+  expect(dynamicError(`1 || false`)).toMatch(`arguments of operator '||' must both be booleans`);
+  expect(dynamicError(`false || ''`)).toMatch(`arguments of operator '||' must both be booleans`);
+  expect(dynamicError(`false || 1`)).toMatch(`arguments of operator '||' must both be booleans`);
+  expect(dynamicError(`1 && false`)).toMatch(`arguments of operator '&&' must both be booleans`);
+  expect(dynamicError(`false && ''`)).toMatch(`arguments of operator '&&' must both be booleans`);
+  expect(dynamicError(`false && 1`)).toMatch(`arguments of operator '&&' must both be booleans`);
+  expect(run(`true || false`)).toBe(true);
+});
+
 describe('ElementaryJS Testing', () => {
 
   beforeEach(() => {

--- a/ts/runtime.ts
+++ b/ts/runtime.ts
@@ -148,7 +148,20 @@ export function applyNumOrStringOp(op: string, lhs: any, rhs: any) {
     }
   }
 }
-
+export function applyBinaryBooleanOp(op: string, lhs: any, rhs: any) {
+  if (typeof lhs !== 'boolean' || typeof rhs !== 'boolean') {
+    throw new ElementaryRuntimeError(`arguments of operator '${op}' must both be booleans`);
+  }
+  switch (op) {
+    case '&&':
+      return (lhs && rhs);
+    case '||':
+      return (lhs || rhs);
+    default:
+      elementaryJSBug(`applyBinaryBooleanOp '${op}'`);
+      return false;
+  }
+}
 export function applyNumOp(op: string, lhs: any, rhs: any) {
   if (!(typeof (lhs) === "number" && typeof (rhs) === "number")) {
     throw new ElementaryRuntimeError(

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -331,6 +331,20 @@ export const visitor = {
       path.skip();
     }
   },
+  LogicalExpression: { // logical expressions only has && and || as operators
+    exit(path: NodePath<t.LogicalExpression>, st: S) {
+      let op = path.node.operator;
+      let opName = t.stringLiteral(op);
+      opName.loc = path.node.loc;
+      path.replaceWith(dynCheck(
+        'applyBinaryBooleanOp',
+        opName,
+        path.node.left,
+        path.node.right, 
+      ));
+      path.skip();
+    }
+  },
   BinaryExpression: {
     enter(path: NodePath<t.BinaryExpression>, st: S) {
       let op = path.node.operator;


### PR DESCRIPTION
- Dynamically check || and && operators for booleans