### PR TITLE
Moved JSONStopified to runtime, Added ObjectStopified

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -39,8 +39,6 @@ class ElementaryRunner implements CompileOK {
   constructor(
     private runner: stopify.AsyncRun & stopify.AsyncEval,
     opts: CompilerOpts) {
-    let JSONStopfied = Object.assign({}, JSON);
-    JSONStopfied.parse = (text: string) => runtime.stopifyObjectArrayRecur(JSON.parse(text))
     const globals = {
       elementaryjs: runtime,
       console: Object.freeze({
@@ -53,13 +51,13 @@ class ElementaryRunner implements CompileOK {
       Array: runtime.Array,
       Math: Math,
       undefined: undefined,
-      Object: Object, // Needed for classes
+      Object: runtime.ObjectStopified, // Needed for classes
       parseInt: parseInt,
       parseFloat: parseFloat,
       hire: hire,
       wheat1: wheat1,
       chaff1: chaff1,
-      JSON: JSONStopfied
+      JSON: runtime.JSONStopified
     };
 
     // We can use .get and .set traps to intercept reads and writes to

--- a/ts/runtime.ts
+++ b/ts/runtime.ts
@@ -306,9 +306,9 @@ export const JSONStopified = getStopifiedJSON();
  */
 function getStopifiedObject() {
   let objectStopified = Object.assign({}, Object);
-  objectStopified.keys = (obj : any) => stopifyObjectArrayRecur(Object.keys(obj));
-  objectStopified.values = (obj: any) => stopifyObjectArrayRecur(Object.values(obj));
-  objectStopified.entries = (obj: any) => stopifyObjectArrayRecur(Object.entries(obj));
+  objectStopified.keys = (obj : any) => stopifyArray(Object.keys(obj));
+  objectStopified.values = (obj: any) => stopifyArray(Object.values(obj));
+  objectStopified.entries = (obj: any) => stopifyArray(Object.entries(obj));
   return objectStopified
 }
 

--- a/ts/runtime.ts
+++ b/ts/runtime.ts
@@ -284,6 +284,35 @@ export class ElementaryTestingError extends Error {
     super(message);
   }
 }
+/**
+ * Returns the default JSON object with the parse function modified to
+ * return a 'stopified' array
+ *
+ * @returns modified JSON object
+ */
+function getStopifiedJSON() {
+  let jsonStopified = Object.assign({}, JSON);
+  jsonStopified.parse = (text: string) => stopifyObjectArrayRecur(JSON.parse(text));
+  return jsonStopified;
+}
+
+export const JSONStopified = getStopifiedJSON();
+
+/**
+ * Returns the default Object object with few functions modified to
+ * return a stopified object.
+ * 
+ * @return modified Object object
+ */
+function getStopifiedObject() {
+  let objectStopified = Object.assign({}, Object);
+  objectStopified.keys = (obj : any) => stopifyObjectArrayRecur(Object.keys(obj));
+  objectStopified.values = (obj: any) => stopifyObjectArrayRecur(Object.values(obj));
+  objectStopified.entries = (obj: any) => stopifyObjectArrayRecur(Object.entries(obj));
+  return objectStopified
+}
+
+export const ObjectStopified = getStopifiedObject();
 
 let tests: TestResult[] = [];
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
         "inlineSourceMap": true,
         "module": "commonjs",
         "outDir": "./dist",
-        "lib": ["es2016", "dom"],
+        "lib": ["es2016", "es2017", "dom"],
         "target": "es2015"
     }
 }


### PR DESCRIPTION
- Moved `JSONStopified` to the runtime module.
- Declare `ObjectStopified` to stopify arrays returned by Object functions
- Added es2017 to lib because Object do not have certain functions before es2017