### PR TITLE
fixed logical operator short circuit bug

### DIFF
--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -762,17 +762,17 @@ test('logical operators short-circuit', async () => {
   await expect(run(`true || 123`)).resolves.toBe(true);
   await expect(run(`false || true`)).resolves.toBe(true);
   await expect(dynamicError(`false || doesNotExists()`)).resolves.toMatch(`doesNotExists is not defined`);
-  await expect(dynamicError(`false || 123`)).resolves.toMatch(`expected a boolean expression, instead received '123'`);
-  await expect(dynamicError(`false || 'as'`)).resolves.toMatch(`expected a boolean expression, instead received 'as'`);
-  await expect(dynamicError(`0 || false`)).resolves.toMatch(`expected a boolean expression, instead received '0'`);  
+  await expect(dynamicError(`false || 123`)).resolves.toMatch(`arguments of operator '||' must both be booleans`);
+  await expect(dynamicError(`false || 'as'`)).resolves.toMatch(`arguments of operator '||' must both be booleans`);
+  await expect(dynamicError(`0 || false`)).resolves.toMatch(`arguments of operator '||' must both be booleans`);  
 
   await expect(run(`false && doesNotExists()`)).resolves.toBe(false);
   await expect(run(`false && 123`)).resolves.toBe(false);
   await expect(run(`false && true`)).resolves.toBe(false);
   await expect(dynamicError(`true && doesNotExists()`)).resolves.toMatch(`doesNotExists is not defined`);
-  await expect(dynamicError(`true && 123`)).resolves.toMatch(`expected a boolean expression, instead received '123'`);
-  await expect(dynamicError(`true && 'as'`)).resolves.toMatch(`expected a boolean expression, instead received 'as'`);
-  await expect(dynamicError(`1 && false`)).resolves.toMatch(`expected a boolean expression, instead received '1'`);
+  await expect(dynamicError(`true && 123`)).resolves.toMatch(`arguments of operator '&&' must both be booleans`);
+  await expect(dynamicError(`true && 'as'`)).resolves.toMatch(`arguments of operator '&&' must both be booleans`);
+  await expect(dynamicError(`1 && false`)).resolves.toMatch(`arguments of operator '&&' must both be booleans`);
 
   await expect(run(`
     function returnTrue() {

--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -757,14 +757,29 @@ test('for statement must have three parts present', async () => {
   `)).resolves.toBe(3);
 });
 
-test('Only booleans for logical operators', async  () => {
-  await expect(dynamicError(`1 || false`)).resolves.toMatch(`arguments of operator '||' must both be booleans`);
-  await expect(dynamicError(`false || ''`)).resolves.toMatch(`arguments of operator '||' must both be booleans`);
-  await expect(dynamicError(`false || 1`)).resolves.toMatch(`arguments of operator '||' must both be booleans`);
-  await expect(dynamicError(`1 && false`)).resolves.toMatch(`arguments of operator '&&' must both be booleans`);
-  await expect(dynamicError(`false && ''`)).resolves.toMatch(`arguments of operator '&&' must both be booleans`);
-  await expect(dynamicError(`false && 1`)).resolves.toMatch(`arguments of operator '&&' must both be booleans`);
-  await expect(run(`true || false`)).resolves.toBe(true);
+test('logical operators short-circuit', async () => {
+  await expect(run(`true || doesNotExists()`)).resolves.toBe(true);
+  await expect(run(`true || 123`)).resolves.toBe(true);
+  await expect(run(`false || true`)).resolves.toBe(true);
+  await expect(dynamicError(`false || doesNotExists()`)).resolves.toMatch(`doesNotExists is not defined`);
+  await expect(dynamicError(`false || 123`)).resolves.toMatch(`expected a boolean expression, instead received '123'`);
+  await expect(dynamicError(`false || 'as'`)).resolves.toMatch(`expected a boolean expression, instead received 'as'`);
+  await expect(dynamicError(`0 || false`)).resolves.toMatch(`expected a boolean expression, instead received '0'`);  
+
+  await expect(run(`false && doesNotExists()`)).resolves.toBe(false);
+  await expect(run(`false && 123`)).resolves.toBe(false);
+  await expect(run(`false && true`)).resolves.toBe(false);
+  await expect(dynamicError(`true && doesNotExists()`)).resolves.toMatch(`doesNotExists is not defined`);
+  await expect(dynamicError(`true && 123`)).resolves.toMatch(`expected a boolean expression, instead received '123'`);
+  await expect(dynamicError(`true && 'as'`)).resolves.toMatch(`expected a boolean expression, instead received 'as'`);
+  await expect(dynamicError(`1 && false`)).resolves.toMatch(`expected a boolean expression, instead received '1'`);
+
+  await expect(run(`
+    function returnTrue() {
+      return true;
+    }
+    !(returnTrue() || doesNotExists()) && doesNotExists();
+  `)).resolves.toBe(false);
 });
 
 test('ElementaryJS statically reports const violations', () => {

--- a/ts/runtime.ts
+++ b/ts/runtime.ts
@@ -201,20 +201,6 @@ export function applyNumOrStringOp(op: string, lhs: any, rhs: any) {
     }
   }
 }
-export function applyBinaryBooleanOp(op: string, lhs: any, rhs: any) {
-  if (typeof lhs !== 'boolean' || typeof rhs !== 'boolean') {
-    throw new ElementaryRuntimeError(`arguments of operator '${op}' must both be booleans`);
-  }
-  switch (op) {
-    case '&&':
-      return (lhs && rhs);
-    case '||':
-      return (lhs || rhs);
-    default:
-      elementaryJSBug(`applyBinaryBooleanOp '${op}'`);
-      return false;
-  }
-}
 export function applyNumOp(op: string, lhs: any, rhs: any) {
   if (!(typeof (lhs) === "number" && typeof (rhs) === "number")) {
     throw new ElementaryRuntimeError(

--- a/ts/runtime.ts
+++ b/ts/runtime.ts
@@ -39,11 +39,14 @@ class ArrayStub {
 
 export { ArrayStub as Array };
 
-export function checkIfBoolean(value: any) {
+export function checkIfBoolean(value: any, operator: '||' | '&&'  | undefined) {
   if (typeof(value) === 'boolean') {
     return value;
   }
-  throw new ElementaryRuntimeError(`expected a boolean expression, instead received '${value}'`);
+  if (typeof operator === 'undefined') { // undefined is for the if statement
+    throw new ElementaryRuntimeError(`expected a boolean expression, instead received '${value}'`);
+  }
+  throw new ElementaryRuntimeError(`arguments of operator '${operator}' must both be booleans`);
 }
 
 export function arrayBoundsCheck(object: any, index: string) {

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -357,14 +357,10 @@ export const visitor = {
   },
   LogicalExpression: { // logical expressions only has && and || as operators
     exit(path: NodePath<t.LogicalExpression>, st: S) {
-      let op = path.node.operator;
-      let opName = t.stringLiteral(op);
-      path.replaceWith(dynCheck(
-        'applyBinaryBooleanOp',
-        path.node.loc,
-        opName,
-        path.node.left,
-        path.node.right, 
+      path.replaceWith(t.logicalExpression(
+        path.node.operator,
+        dynCheck('checkIfBoolean', path.node.left.loc, path.node.left),
+        dynCheck('checkIfBoolean', path.node.right.loc, path.node.right)
       ));
       path.skip();
     }

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -357,10 +357,11 @@ export const visitor = {
   },
   LogicalExpression: { // logical expressions only has && and || as operators
     exit(path: NodePath<t.LogicalExpression>, st: S) {
+      const operatorString = t.stringLiteral(path.node.operator);
       path.replaceWith(t.logicalExpression(
         path.node.operator,
-        dynCheck('checkIfBoolean', path.node.left.loc, path.node.left),
-        dynCheck('checkIfBoolean', path.node.right.loc, path.node.right)
+        dynCheck('checkIfBoolean', path.node.left.loc, path.node.left, operatorString),
+        dynCheck('checkIfBoolean', path.node.right.loc, path.node.right, operatorString)
       ));
       path.skip();
     }


### PR DESCRIPTION
- fixed bug with `&&` and `||` not short-circuiting