### PR TITLE
Bump project-interpreter version

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-types": "^6.26.0",
     "stopify": "0.5.3-elementaryJS",
-    "@stopify/project-interpreter": "1.1.0"
+    "@stopify/project-interpreter": "1.1.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16,9 +16,10 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@stopify/project-interpreter@1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@stopify/project-interpreter/-/project-interpreter-1.1.0.tgz#ff54865f72878d9845bf7d70a55fbbfa82fa00a5"
+"@stopify/project-interpreter@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@stopify/project-interpreter/-/project-interpreter-1.1.3.tgz#3cec09820e279571df3a3750bf958d2e095befc1"
+  integrity sha512-b0eSJiQI7DRqQ5uYEl6ohSk+h7mcGsO3hSztD9EO7dQIwzUIQqjx9XmJ0umUNagGK9TxxX/eCcn48moYR3615w==
   dependencies:
     immutable "^4.0.0-rc.12"
     parsimmon "^1.12.0"


### PR DESCRIPTION
- Bump @stopify/project-interpreter from 1.1.0 to 1.1.3