### PR TITLE
Stopify arrays returned by parser functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stopify/elementary-js",
-  "version": "1.0.16",
+  "version": "1.0.17",
   "description": "JavaScript without sharp edges",
   "main": "dist/index.js",
   "author": [

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -62,8 +62,8 @@ class ElementaryRunner implements CompileOK {
       chaff1: chaff1,
       JSON: JSONStopfied,
       parser: Object.freeze({
-        parseProgram: interpreter.parseProgram,
-        parseExpression: interpreter.parseExpression
+        parseProgram: (input: string) => runtime.stopifyObjectArrayRecur(interpreter.parseProgram(input)),
+        parseExpression: (input: string) => runtime.stopifyObjectArrayRecur(interpreter.parseExpression(input))
       }),
       geometry: Object.freeze({
         Point: lib220.newPoint,


### PR DESCRIPTION
- Stopify arrays returned by parser functions so that higher-order functions work properly.