### PR TITLE
Disallow arrow funcs

### DIFF
--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -834,6 +834,17 @@ test('parseFloat is available', async () => {
   await expect(run(`parseFloat("3.14159")`)).resolves.toBe(3.14159);
 });
 
+test('Disallow arrow functions', async () => {
+  await expect(staticError('const s = () => 1; s()')).toEqual(
+    expect.arrayContaining([
+      `Do not use arrow functions.`
+  ]));
+  await expect(staticError('(() => 1)()')).toEqual(
+    expect.arrayContaining([
+      `Do not use arrow functions.`
+  ]));
+});
+
 describe('ElementaryJS Testing', () => {
 
   beforeEach(() => {

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -561,7 +561,12 @@ export const visitor = {
   },
   ForInStatement(path: NodePath<t.ForInStatement>, st: S) {
     st.elem.error(path, `Do not use for-in loops.`);
-  }
+  },
+  ArrowFunctionExpression(path: NodePath<t.ArrowFunctionExpression>, st: S) {
+    st.elem.error(path, `Do not use arrow functions.`);
+    path.skip();
+    return;
+  },
 }
 
 // Allows ElementaryJS to be used as a Babel plugin.


### PR DESCRIPTION
 - A temporary fix to the current error message we have for arrow functions