### PR TITLE
Use padding and display block instead of br for generating canvases.

### DIFF
--- a/ts/lib220.ts
+++ b/ts/lib220.ts
@@ -191,7 +191,8 @@ export class DrawingCanvas {
     canvas.setAttribute('width', this.width.toString());
     canvas.setAttribute('height', this.height.toString());
     this.ctx = canvas.getContext('2d')!;
-    canvases.appendChild(document.createElement('br'));
+    canvas.style.paddingBottom = '5px';
+    canvas.style.display = 'block';
     canvases.appendChild(canvas);
     this.ctx.fillStyle = "white";
     this.ctx.fillRect(0, 0, this.width, this.height);
@@ -327,7 +328,8 @@ function EncapsulatedImage(imageData: any) {
       canvas.setAttribute('height', h);
       const ctx = canvas.getContext('2d')!;
       ctx.putImageData(imageData, 0, 0);
-      canvases.appendChild(document.createElement('br'));
+      canvas.style.display = 'block';
+      canvas.style.paddingBottom = '5px';
       canvases.appendChild(canvas);
     },
     setPixel: function(x: any, y: any, c: any) {


### PR DESCRIPTION
![screenshot from 2019-01-26 19-21-15](https://user-images.githubusercontent.com/25542608/51794377-9a138d00-219f-11e9-87a0-94fc19b03184.png)
- Ocelot removes children inside the canvases div when the number of children exceed some number. As more children are added, it removes them one by one. It'll then remove `<br />` tags half the time, and that may not be ideal.
