### PR TITLE
Fix.

### DIFF
--- a/ts/index.ts
+++ b/ts/index.ts
@@ -35,11 +35,8 @@ class ElementaryRunner implements CompileOK {
     opts: CompilerOpts) {
 
     this.codeMap = {};
-    const whitelistCode = opts.whitelistCode;
-    if (whitelistCode) {
-      Object.keys(whitelistCode).forEach((moduleName) => {
-        this.codeMap[moduleName] = eval(`(${whitelistCode[moduleName]})`);
-      });
+    for (const moduleName in opts.whitelistCode) {
+      this.codeMap[moduleName] = eval(`(${opts.whitelistCode[moduleName]})`);
     }
 
     const JSONStopfied = Object.assign({}, JSON);


### PR DESCRIPTION
- `whitelistCode` is _not_ optional.
- Use straightforward `for...in`; we don't have to worry about members on prototype here.