### PR TITLE
Bump version + updated stopify ejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stopify/elementary-js",
-  "version": "1.0.22",
+  "version": "1.0.23",
   "description": "JavaScript without sharp edges",
   "main": "dist/index.js",
   "author": [
@@ -54,7 +54,7 @@
     "babel-core": "^6.26.3",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-types": "^6.26.0",
-    "stopify": "0.5.3-elementaryJS",
+    "stopify": "0.5.4-elementaryJS",
     "@stopify/project-interpreter": "1.1.4"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3629,9 +3629,10 @@ stopify-estimators@^0.5.0:
   dependencies:
     detect-browser "^1.12.0"
 
-stopify@0.5.3-elementaryJS:
-  version "0.5.3-elementaryJS"
-  resolved "https://registry.yarnpkg.com/stopify/-/stopify-0.5.3-elementaryJS.tgz#e462c1d655656ca4c46edb689964867450929c7c"
+stopify@0.5.4-elementaryJS:
+  version "0.5.4-elementaryJS"
+  resolved "https://registry.yarnpkg.com/stopify/-/stopify-0.5.4-elementaryJS.tgz#7ec3dbcad87d5691a671cab6311b4a304c715f6f"
+  integrity sha512-9Yrz6mYW7wLZPu7NGAF/vwc1dOPPjk+NtnczEf6OU12HaEmT59LReujPJkcCVFCx/XYH/UTEYPuVwjtZW00gKw==
   dependencies:
     babel-core "^6.26.3"
     babel-loader "^7.1.2"


### PR DESCRIPTION
- Bump EJS version and use new version of stopify for EJS
- Note: the published version does not contain code related to `require` since `require` is still in beta.