### PR TITLE
Disallow accessing function prototype properties

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -120,7 +120,7 @@ export function dot(object: any, index: string, line: number) {
     errorHandle('cannot access member of non-object value types', 'dot', line);
   }
   if (object && !object.hasOwnProperty(index)) {
-    errorHandle(`object does not have own member '${index}'`, 'dot', line);
+    errorHandle(`object does not have member '${index}'`, 'dot', line);
   }
   if (typeof object === 'string' && index === 'split') {
     return function(sep: string) {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -115,11 +115,12 @@ export function dot(object: any, index: string, line: number) {
   if (typeof object !== 'object'  &&
       typeof object !== 'string'  &&
       typeof object !== 'boolean' &&
-      typeof object !== 'number') {
+      typeof object !== 'number'  &&
+      typeof object !== 'function') {
     errorHandle('cannot access member of non-object value types', 'dot', line);
   }
   if (object && !object.hasOwnProperty(index)) {
-    errorHandle(`object does not have member '${index}'`, 'dot', line);
+    errorHandle(`object does not have own member '${index}'`, 'dot', line);
   }
   if (typeof object === 'string' && index === 'split') {
     return function(sep: string) {
@@ -127,6 +128,13 @@ export function dot(object: any, index: string, line: number) {
     };
   }
   return object && object[index];
+}
+
+export function checkFunction(object: any, index: string, result: any, line: number) {
+  if (typeof object === 'function' && index in Function.prototype) {
+    errorHandle('Cannot call default properties of functions', 'checkFunction', line);
+  }
+  return result;
 }
 
 export function updateOnlyNumbers(opcode: string, object: any, line: number) {

--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -1012,13 +1012,13 @@ test('Dynamic error on calling functions access with brackets', async () => {
   `)).resolves.toMatch(`array indexing called on a non-array value type`);
 });
 
-test.only('Disallow function toString access', async () => {
+test('Disallow function toString access', async () => {
   await expect(dynamicError(`
     function funcA() {
       return 1;
     }
     funcA.toString;
-  `)).resolves.toMatch(`object does not have own member 'toString'`);
+  `)).resolves.toMatch(`object does not have member 'toString'`);
   await expect(dynamicError(`
     function funcA() {
       return 1;
@@ -1032,7 +1032,7 @@ test.only('Disallow function toString access', async () => {
       }
     }
     TestClass.testFunc.toString;
-  `)).resolves.toMatch(`object does not have own member 'toString'`);
+  `)).resolves.toMatch(`object does not have member 'toString'`);
   await expect(dynamicError(`
     class TestClass {
       static testFunc() {
@@ -1043,7 +1043,7 @@ test.only('Disallow function toString access', async () => {
   `)).resolves.toMatch(`Cannot call default properties of functions`);
   await expect(dynamicError(`
     Array.toString;
-  `)).resolves.toMatch(`object does not have own member 'toString'`);
+  `)).resolves.toMatch(`object does not have member 'toString'`);
   await expect(dynamicError(`
     Array.toString()
   `)).resolves.toMatch(`Cannot call default properties of functions`);


### PR DESCRIPTION
- Disallow accessing function prototype properties
  - e.g. disallow `function.toString()`, `classFunc.function.toString()`
- Fix minor bug with accessing functions from functions with brackets
  - e.g. `something['funcName']()` is disallowed
- `ts/visitor.ts`
  - `CallExpression`'s `exit`
    - Minor clean up and added new dynamic check, `checkFunction`.
  - `MemberExpression`'s `exit`
    - Cleaned up and fixed bug related to accessing function with brackets

