### PR TITLE
Arrow Function bug fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,11 +52,12 @@
     "typescript": "^3.3.3"
   },
   "dependencies": {
+    "@stopify/project-interpreter": "1.1.4",
     "@types/babel-types": "^6.7.16",
     "babel-core": "^6.26.3",
+    "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-classes": "^6.24.1",
     "babel-types": "^6.26.0",
-    "stopify": "0.5.4-elementaryJS",
-    "@stopify/project-interpreter": "1.1.4"
+    "stopify": "0.5.4-elementaryJS"
   }
 }

--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -891,7 +891,7 @@ test('Disallow rest params', async () => {
 });
 
 test('Arrow functions inherit this', async () => {
-  expect.assertions(1);
+  expect.assertions(2);
   await expect(run(`
   class TestClass {
     constructor() {
@@ -907,7 +907,26 @@ test('Arrow functions inherit this', async () => {
   }
 
   new TestClass().arrowFuncTest();`)).resolves.toBe('abcdef');
+
+  await expect(run(`
+  class TestClass {
+    constructor() {
+      this.data = 1;
+    }
+    nestedArrow() {
+      return (() => (() => this.data)() + 1)();
+    }
+  }
+  new TestClass().nestedArrow();
+  `)).resolves.toBe(2);
 });
+
+test('Arrow functions has arity checking', async () => {
+  await expect(dynamicError(`
+  let a = (a) => 1;
+  a();
+  `)).resolves.toMatch('function (anonymous) expected 1 argument but received 0 arguments');
+})
 
 test('Arrow functions have no implicit params', async () => {
   expect.assertions(2);

--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -881,7 +881,7 @@ test('Allow arrow functions with expression bodies', async () => {
 });
 
 test('Allow arrow functions with block bodies', async () => {
-  await expect(run(`(function(x) { return x + 1; })(10)`)).resolves.toBe(11);
+  await expect(run(`((x) => { return x + 1; })(10)`)).resolves.toBe(11);
 });
 
 test('Disallow rest params', async () => {

--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -890,6 +890,25 @@ test('Disallow rest params', async () => {
   ]));
 });
 
+test('Arrow functions work with this', async () => {
+  await expect(run(`
+  class TestClass {
+    constructor() {
+      this.data = "abcde";
+    }
+
+    arrowFuncTest() {
+      let k = () => {
+        return this.data + "f";
+      }
+      return k();
+    }
+  }
+
+  new TestClass().arrowFuncTest();`)).resolves.toEqual("abcdef");
+
+});
+
 test('Parser should work', async () => {
   await expect(run(`
     parser.parseProgram('let x = 1; let y = x * 2;').kind;

--- a/test/unit-tests.test.ts
+++ b/test/unit-tests.test.ts
@@ -938,7 +938,6 @@ test('Arrow functions have no implicit params', async () => {
 
    a.c();`)).resolves.toMatch(`cannot access member of non-object value types`);
 
-  // A product of the Babel plugin we'll have to live with for now:
   await expect(run(`
   let a = {
     b: 0,

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -169,20 +169,25 @@ function applyElementaryJS(
       babylon.parse(code).program : code;
     const result1 = babel.transformFromAst(ast,
       typeof code === 'string' && code || undefined, {
-      plugins: [ [visitor.plugin] ],
+      plugins: [ transformArrowFunctions ],
       ast: true,
-      code: true
+      code: true,
     });
 
     const result2 = babel.transformFromAst(result1.ast!, result1.code!, {
-      plugins: [transformArrowFunctions, transformClasses],
+      plugins: [ [visitor.plugin] ],
+      code: true,
+    });
+
+    const result3 = babel.transform(result2.code!, {
+      plugins: [ transformClasses ],
       ast: true,
       code: false
     });
     // NOTE(arjun): There is some imprecision in the type produced by Babel.
     // I have verified that this cast is safe.
     return {
-      ast: (result2.ast! as babel.types.File).program,
+      ast: (result3.ast! as babel.types.File).program,
       kind: 'ok'
     };
   }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -169,20 +169,15 @@ function applyElementaryJS(
       babylon.parse(code).program : code;
     const result1 = babel.transformFromAst(ast,
       typeof code === 'string' && code || undefined, {
-      plugins: [ transformArrowFunctions ],
-      ast: true,
-      code: true,
+      plugins: [ transformArrowFunctions ]
     });
 
     const result2 = babel.transformFromAst(result1.ast!, result1.code!, {
-      plugins: [ [visitor.plugin] ],
-      code: true,
-      ast: true,
+      plugins: [ [visitor.plugin] ]
     });
 
     const result3 = babel.transformFromAst(result2.ast!, result2.code!, {
       plugins: [ transformClasses ],
-      ast: true,
       code: false
     });
     // NOTE(arjun): There is some imprecision in the type produced by Babel.

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -177,9 +177,10 @@ function applyElementaryJS(
     const result2 = babel.transformFromAst(result1.ast!, result1.code!, {
       plugins: [ [visitor.plugin] ],
       code: true,
+      ast: true,
     });
 
-    const result3 = babel.transform(result2.code!, {
+    const result3 = babel.transformFromAst(result2.ast!, result2.code!, {
       plugins: [ transformClasses ],
       ast: true,
       code: false

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -169,21 +169,17 @@ function applyElementaryJS(
       babylon.parse(code).program : code;
     const result1 = babel.transformFromAst(ast,
       typeof code === 'string' && code || undefined, {
-      plugins: [ transformArrowFunctions ]
+      plugins: [ transformArrowFunctions, [visitor.plugin] ]
     });
 
     const result2 = babel.transformFromAst(result1.ast!, result1.code!, {
-      plugins: [ [visitor.plugin] ]
-    });
-
-    const result3 = babel.transformFromAst(result2.ast!, result2.code!, {
       plugins: [ transformClasses ],
       code: false
     });
     // NOTE(arjun): There is some imprecision in the type produced by Babel.
     // I have verified that this cast is safe.
     return {
-      ast: (result3.ast! as babel.types.File).program,
+      ast: (result2.ast! as babel.types.File).program,
       kind: 'ok'
     };
   }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -22,6 +22,7 @@ theGlobal.stopify = stopify;
 // NOTE(arjun): This may not be needed, but I am using require instead of the
 // name so that Webpack can statically link.
 const transformClasses = require('babel-plugin-transform-es2015-classes');
+const transformArrowFunctions = require('babel-plugin-transform-es2015-arrow-functions');
 
 class ElementaryRunner implements CompileOK {
   public g: { [key: string]: any };
@@ -172,8 +173,15 @@ function applyElementaryJS(
       ast: true,
       code: true
     });
-    const result2 = babel.transformFromAst(result1.ast!,
-      result1.code!, {
+
+    const result2 = babel.transformFromAst(result1.ast!, result1.code!, {
+      plugins: [transformArrowFunctions],
+      ast: true,
+      code: true
+    })
+
+    const result3 = babel.transformFromAst(result2.ast!,
+      result2.code!, {
         plugins: [transformClasses],
         ast: true,
         code: false
@@ -181,7 +189,7 @@ function applyElementaryJS(
     // NOTE(arjun): There is some imprecision in the type produced by Babel.
     // I have verified that this cast is safe.
     return {
-      ast: (result2.ast! as babel.types.File).program,
+      ast: (result3.ast! as babel.types.File).program,
       kind: 'ok'
     };
   }

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -12,17 +12,17 @@ import * as runtime from './runtime';
 import * as interpreter from '@stopify/project-interpreter';
 import * as fs from 'fs';
 
+// NOTE(arjun): This may not be needed, but I am using require instead of the
+// name so that Webpack can statically link.
+const transformArrowFunctions = require('babel-plugin-transform-es2015-arrow-functions'),
+      transformClasses = require('babel-plugin-transform-es2015-classes');
+
 // TODO(arjun): I think these hacks are necessary for eval to work. We either
 // do them here or we do them within the implementation of Stopify. I want
 // them here for now until I'm certain there isn't a cleaner way.
 const theGlobal: any = (typeof window !== 'undefined') ? window : global;
 theGlobal.elementaryJS = runtime;
 theGlobal.stopify = stopify;
-
-// NOTE(arjun): This may not be needed, but I am using require instead of the
-// name so that Webpack can statically link.
-const transformClasses = require('babel-plugin-transform-es2015-classes');
-const transformArrowFunctions = require('babel-plugin-transform-es2015-arrow-functions');
 
 class ElementaryRunner implements CompileOK {
   public g: { [key: string]: any };

--- a/ts/index.ts
+++ b/ts/index.ts
@@ -175,21 +175,14 @@ function applyElementaryJS(
     });
 
     const result2 = babel.transformFromAst(result1.ast!, result1.code!, {
-      plugins: [transformArrowFunctions],
+      plugins: [transformArrowFunctions, transformClasses],
       ast: true,
-      code: true
-    })
-
-    const result3 = babel.transformFromAst(result2.ast!,
-      result2.code!, {
-        plugins: [transformClasses],
-        ast: true,
-        code: false
+      code: false
     });
     // NOTE(arjun): There is some imprecision in the type produced by Babel.
     // I have verified that this cast is safe.
     return {
-      ast: (result3.ast! as babel.types.File).program,
+      ast: (result2.ast! as babel.types.File).program,
       kind: 'ok'
     };
   }

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -528,6 +528,11 @@ export const visitor = {
     }
   },
   VariableDeclaration(path: NodePath<t.VariableDeclaration>, st: S) {
+    if (typeof (path.node as any)._generated !== 'undefined' 
+        && (path.node as any)._generated 
+        && path.node.kind === 'var') {
+          return;
+    }
     if (path.node.kind !== 'let' && path.node.kind !== 'const') {
       st.elem.error(path, `Use 'let' or 'const' to declare a variable.`);
     }

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -177,18 +177,6 @@ export const visitor = {
       }
     }
   },
-  ArrowFunctionExpression: {
-    enter(path: NodePath<t.ArrowFunctionExpression>) {
-      if (t.isBlockStatement(path.node.body)) {
-        path.replaceWith(t.functionExpression(undefined, path.node.params,
-          path.node.body));
-      }
-      else {
-        path.replaceWith(t.functionExpression(undefined, path.node.params,
-          t.blockStatement([t.returnStatement(path.node.body)])));
-      }
-    }
-  },
   Function: {
     enter(path: NodePath<t.Function>, st: S) {
       if (path.node.params.length &&

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -192,6 +192,13 @@ export const visitor = {
     },
     exit(path: NodePath<t.Function>, st: S) {
       st.elem.inConstructor = st.elem.inConstructorStack.pop()!
+      if ((path.node as any).shadow) {
+        // Babel arrow function transform leave shadow as true when
+        // they transformed an arrow function to a function.
+        // After inserting dynamic checks, the class transform relies on
+        // shadow to do extra work on functions (like renaming arguments)
+        (path.node as any).shadow = undefined;
+      }
 
       // Inserts the expression `dynCheck(N, arguments.length, name)` at the
       // top of the function, where N is the number of declared arguments
@@ -204,7 +211,6 @@ export const visitor = {
       const name = t.stringLiteral(id ? id.name : '(anonymous)');
       body.unshift(t.expressionStatement(
         dynCheck('arityCheck', path.node.loc, name, expected, actual)));
-
       path.skip();
     },
   },

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -530,7 +530,7 @@ export const visitor = {
     }
   },
   VariableDeclaration(path: NodePath<t.VariableDeclaration>, st: S) {
-    // Arrow transform uses "var" declarations.
+    // Arrow transform uses "var" declarations, we can skip over them instead
     if ((path.node as any)._generated && path.node.kind === 'var') {
       return;
     }

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -193,10 +193,11 @@ export const visitor = {
     exit(path: NodePath<t.Function>, st: S) {
       st.elem.inConstructor = st.elem.inConstructorStack.pop()!
       if ((path.node as any).shadow) {
-        // Babel arrow function transform leave shadow as true when
-        // they transformed an arrow function to a function.
-        // After inserting dynamic checks, the class transform relies on
-        // shadow to do extra work on functions (like renaming arguments)
+        //  Note(Sam L.) Babel arrow function transform leave shadow as true when
+        // it transforms an arrow function to a function.
+        // The class transform relies on shadow to do extra work on arrow functions 
+        // (like using arguments that is in the outer scope instead of inner scope)
+        // That is unnecessary as it breaks aritychecking so it is set as undefined.
         (path.node as any).shadow = undefined;
       }
 

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -177,11 +177,6 @@ export const visitor = {
       }
     }
   },
-  ArrowFunctionExpression: {
-    enter(path: NodePath<t.ArrowFunctionExpression>) {
-      path.skip(); // TODO
-    }
-  },
   Function: {
     enter(path: NodePath<t.Function>, st: S) {
       if (path.node.params.length &&
@@ -528,10 +523,9 @@ export const visitor = {
     }
   },
   VariableDeclaration(path: NodePath<t.VariableDeclaration>, st: S) {
-    if (typeof (path.node as any)._generated !== 'undefined' 
-        && (path.node as any)._generated 
-        && path.node.kind === 'var') {
-          return;
+    // Arrow transform uses "var" declarations.
+    if ((path.node as any)._generated && path.node.kind === 'var') {
+      return;
     }
     if (path.node.kind !== 'let' && path.node.kind !== 'const') {
       st.elem.error(path, `Use 'let' or 'const' to declare a variable.`);

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -177,6 +177,11 @@ export const visitor = {
       }
     }
   },
+  ArrowFunctionExpression: {
+    enter(path: NodePath<t.ArrowFunctionExpression>) {
+      path.skip(); // TODO
+    }
+  },
   Function: {
     enter(path: NodePath<t.Function>, st: S) {
       if (path.node.params.length &&

--- a/ts/visitor.ts
+++ b/ts/visitor.ts
@@ -192,13 +192,15 @@ export const visitor = {
     },
     exit(path: NodePath<t.Function>, st: S) {
       st.elem.inConstructor = st.elem.inConstructorStack.pop()!
-      if ((path.node as any).shadow) {
+      if (path.has('shadow')) {
         //  Note(Sam L.) Babel arrow function transform leave shadow as true when
         // it transforms an arrow function to a function.
-        // The class transform relies on shadow to do extra work on arrow functions 
-        // (like using arguments that is in the outer scope instead of inner scope)
-        // That is unnecessary as it breaks aritychecking so it is set as undefined.
-        (path.node as any).shadow = undefined;
+        // Babel's shadow functions are just traditional functions but act like
+        // arrow functions (i.e has lexical binding of this and arguments)
+        // It's to let other plugins see if additional transform needs to be done
+        // on these functions. The classes transform would assume the arity
+        // checking we did was using lexical binding of arguments, but we're not.
+        (path.node as any).shadow = undefined; // therefore this is set to undefined
       }
 
       // Inserts the expression `dynCheck(N, arguments.length, name)` at the

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,6 +687,7 @@ babel-plugin-jest-hoist@^24.3.0:
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz#452692cb711d5f79dc7f85e440ce41b9f244d221"
+  integrity sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=
   dependencies:
     babel-runtime "^6.22.0"
 


### PR DESCRIPTION
- Use Babel plugin for arrow functions
- Transforms code by doing: Babel Arrow Function Transform -> EJS visitor -> Babel Classes Transform
- Made changes to EJS visitor to accommodate for the changes done by the arrow function transform 
- Arrow functions do not have its own binding for `arguments` but it can refer to a global `arguments` object that is declared by Stopify (specified in the AST).
- Wrote unit tests
  - Arrow functions do not have its own `this`
  - Arity checking works