### PR TITLE
RT error line numbs when "off".

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@stopify/elementary-js",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JavaScript without sharp edges",
   "main": "dist/index.js",
   "author": [
@@ -43,6 +43,7 @@
     "@types/babel-core": "^6.7.14",
     "@types/babel-generator": "^6.7.14",
     "@types/babel-traverse": "^6.7.17",
+    "@types/babel-types": "^6.7.16",
     "@types/jest": "^24.0.11",
     "@types/node": "^11.11.6",
     "jest": "^24.5.0",
@@ -54,8 +55,7 @@
   "dependencies": {
     "@stopify/higher-order-functions": "0.7.1",
     "@stopify/project-interpreter": "1.1.4",
-    "@stopify/stopify": "0.7.1",
-    "@types/babel-types": "^6.7.16",
+    "@stopify/stopify": "0.7.2",
     "babel-core": "^6.26.3",
     "babel-plugin-transform-es2015-arrow-functions": "^6.22.0",
     "babel-plugin-transform-es2015-classes": "^6.24.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ class ElementaryRunner implements CompileOK {
       stopifyArray: runtime.stopifyArray,
       stopifyObjectArrayRecur: runtime.stopifyObjectArrayRecur
     }`;
-    Object.keys(opts.whitelistCode).forEach((moduleName) => {
+    Object.keys(opts.whitelistCode).forEach((moduleName: string) => {
       this.codeMap[moduleName] = eval(`(${opts.whitelistCode[moduleName]}(${config}))`);
     });
 
@@ -59,7 +59,7 @@ class ElementaryRunner implements CompileOK {
       Array: runtime.Array,
       Math: Math,
       undefined: undefined,
-      Infinity: Infinity,
+      Infinity: Number.POSITIVE_INFINITY,
       Object: Object, // Needed for classes
       parseInt: Number.parseInt,
       parseFloat: Number.parseFloat,
@@ -117,7 +117,7 @@ class ElementaryRunner implements CompileOK {
       throw Error('Invalid runner in run');
     }
     eRunner.value.isRunning = true;
-    this.runner.run((result) => {
+    this.runner.run((result: Result) => {
       eRunner.value.isRunning = false;
       onDone(result);
     });
@@ -137,7 +137,7 @@ class ElementaryRunner implements CompileOK {
       throw Error('Invalid runner in eval');
     }
     eRunner.value.isRunning = true;
-    this.runner.evalAsyncFromAst(elementary.ast, (result) => {
+    this.runner.evalAsyncFromAst(elementary.ast, (result: Result) => {
       eRunner.value.isRunning = false;
       onDone(result);
     });
@@ -150,7 +150,7 @@ class ElementaryRunner implements CompileOK {
     }
     eRunner.value.isRunning = false;
     eRunner.value.onStopped = onStopped;
-    this.runner.pause((line) => {
+    this.runner.pause(() => {
       onStopped();
     });
   }

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -53,7 +53,7 @@ class ArrayStub {
 
 export { ArrayStub as Array };
 
-export function checkIfBoolean(value: any, operator: '||' | '&&'  | undefined) {
+export function checkIfBoolean(value: any, operator: '||' | '&&' | undefined) {
   if (typeof value !== 'boolean' && !operator) { // for the if statement
     errorHandle(`expected a boolean expression, instead received '${value}'`, 'checkIfBoolean');
   } else if (typeof value !== 'boolean') {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -288,11 +288,10 @@ export function setRunner(runner: stopify.AsyncRun) {
 }
 
 /**
- * Enable/Disable testing and sets a stopify runner if needed.
- * It clears out previous tests and starts anew.
+ * Enable/Disable testing; it clears out previous tests and starts anew.
  *
  * @param {boolean} enable
- * @param {*} runner
+ * @param {number} timeout
  */
 export function enableTests(enable: boolean, timeout: number = 5000) {
   testsEnabled = enable;
@@ -376,10 +375,10 @@ export function test(description: string, testFunction: () => void) {
  * Output can be styled with the hasStyles argument.
  *
  * @param {boolean} hasStyles to determine whether it needs styling (for console.log)
- * @returns an object with output (string) and style, (array of string).
+ * @returns an object with output (string) and style (array of string).
  * If hasStyles is false, object will contain proper output string in output
  * field and no styling. If hasStyling is true, markers are placed in output
- * and styling is given in the style field to be used in console.log
+ * and styling is given in the style field to be used in console.log.
  */
 export function summary(hasStyles: boolean) {
   if (!testsEnabled) {

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -63,6 +63,7 @@ interface S {
 }
 
 function dynCheck(name: string, loc: t.SourceLocation, ...args: t.Expression[]): t.CallExpression {
+  args.push(t.numericLiteral(loc.start.line)); // line numb is last arg to any dyn check
   const f = t.memberExpression(t.identifier('rts'), t.identifier(name), false),
         c = t.callExpression(f, args);
   c.loc = loc;

--- a/src/visitor.ts
+++ b/src/visitor.ts
@@ -289,7 +289,7 @@ const visitor = {
         path.replaceWith(t.assignmentExpression('=', left,
           t.binaryExpression(unassign(op), left, right)));
       } else {
-        // exp.x += rhs =>  tmp = exp, tmp.x = tmp.x + rhs
+        // exp.x += rhs => tmp = exp, tmp.x = tmp.x + rhs
         const tmp = path.scope.generateUidIdentifier('tmp');
         enclosingScopeBlock(path).push(
           t.variableDeclaration('var', [
@@ -464,7 +464,7 @@ const visitor = {
     exit(path: NodePath<t.IfStatement>, st: S) {
       // if (a) => if (checkIfBoolean(a))
       const a = path.node.test,
-            check = dynCheck('checkIfBoolean', path.node.loc, a),
+            check = dynCheck('checkIfBoolean', path.node.loc, a, t.nullLiteral()),
             consequent = path.node.consequent,
             alternate = path.node.alternate,
             replacement = t.ifStatement(check, consequent, alternate);
@@ -505,7 +505,7 @@ const visitor = {
   ForInStatement(path: NodePath<t.ForInStatement>, st: S) {
     st.elem.error(path, 'Do not use for-in loops.');
   }
-}
+};
 
 // Allows ElementaryJS to be used as a Babel plugin.
 export function plugin(ejsOff: boolean) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -365,10 +365,10 @@
     immutable "^4.0.0-rc.12"
     parsimmon "^1.12.0"
 
-"@stopify/stopify@0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@stopify/stopify/-/stopify-0.7.1.tgz#2a42907dd2b950a6ec030e9ed088ed88a23b36b0"
-  integrity sha512-sZHJGpnWfOAaeR9kn0C2LKl6PeDF1hhTpvAqITCVfwKsPPridji5wJltZfzvUP06e2Ck3kegH+7e+YoBaiK88Q==
+"@stopify/stopify@0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@stopify/stopify/-/stopify-0.7.2.tgz#a3438bf8a1937c4f6e38d5a7c1622262531fccff"
+  integrity sha512-tTpgUpz5fULKINiop1FUsjGWny1jxmOmc6SbwRs3i1Mk9Yck83qbV2FrYXqloRz/c4wp6ADLeBrXfWzXtmBHfA==
   dependencies:
     "@stopify/continuations" "0.7.1"
     "@stopify/continuations-runtime" "0.7.1"


### PR DESCRIPTION
Add support for line numbers when running EJS in "off" (i.e. log errors, don't throw) mode. This is for future analysis. Along the way fixed an undocumented bug, wherein line numbers are _not_ provided for runtime errors involving shorthand assignment operators. Also, some small updates/cleanup.